### PR TITLE
Cmd line args

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace ConsoleApplication
             var parserResult = Parser.Default.ParseArguments<Options>(args);
 
             await parserResult.WithParsedAsync(async options =>
-                {
+            {
 
                 if (options.URL != null)
                 {
@@ -45,7 +45,7 @@ namespace ConsoleApplication
             });
         }
 
-        private static async Task TxtParserRoutine (string FileName)
+        private static async Task TxtParserRoutine(string FileName)
         {
             GridBot Gunnar = new GridBot(Power, Calibrate, Rows, Cols);
             TxtParser TParser = new TxtParser();
@@ -55,7 +55,7 @@ namespace ConsoleApplication
             Gunnar.CleanUp();
         }
 
-        private static async Task WebSocketRoutine (bool Dummy, string URL)
+        private static async Task WebSocketRoutine(bool Dummy, string URL)
         {
             AppCmdParser cmdParser = null;
             GridBot Gunnar;

--- a/Program.cs
+++ b/Program.cs
@@ -25,21 +25,22 @@ namespace ConsoleApplication
         static async Task Main(string[] args)
         {
 
-            Parser.Default.ParseArguments<Options>(args)
-                .WithParsed(options =>
+            var parserResult = Parser.Default.ParseArguments<Options>(args);
+
+            await parserResult.WithParsedAsync(async options =>
                 {
 
                 if (options.URL != null)
                 {
                     Console.WriteLine($"Using URL: {options.URL}");
 
-                    WebSocketRoutine(options.Dummy, options.URL);
+                    await WebSocketRoutine(options.Dummy, options.URL);
                 }
-                else if (options.TxtFile != null)
+                    else if (options.TxtFile != null)
                 {
                     Console.WriteLine($"Using txtParser to run file: {options.TxtFile}");
 
-                    TxtParserRoutine(options.TxtFile);
+                    await TxtParserRoutine(options.TxtFile);
                 }
             });
         }
@@ -65,28 +66,30 @@ namespace ConsoleApplication
                 cmdParser = new AppCmdParser(Gunnar);
             }
 
-            string[] args = { "-u", URL };
+            string[] args = { "--urls", URL };
 
             var builder = WebApplication.CreateBuilder(args);
             var app = builder.Build();
 
             app.UseWebSockets();
 
+            Console.WriteLine("Test4");
+
             app.Use(async (context, next) =>
             {
+                Console.WriteLine("Test5");
                 if (context.WebSockets.IsWebSocketRequest)
                 {
+
                     WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                    Console.WriteLine("Test6");
+
+
                     Console.WriteLine("The frontend is connected");
                     WebSocketHandler webSocketHandler = new WebSocketHandler(webSocket);
-                    if (!Dummy)
-                    {
-                        await webSocketHandler.HandleWebSocketAsync(cmdParser);
-                    } 
-                    else
-                    {
-                        await webSocketHandler.HandleWebSocketAsync();
-                    }
+
+                    await webSocketHandler.HandleWebSocketAsync(cmdParser);
+
                     Console.WriteLine("after socket messages");
                 }
                 else

--- a/Program.cs
+++ b/Program.cs
@@ -36,7 +36,7 @@ namespace ConsoleApplication
 
                     await WebSocketRoutine(options.Dummy, options.URL);
                 }
-                    else if (options.TxtFile != null)
+                else if (options.TxtFile != null)
                 {
                     Console.WriteLine($"Using txtParser to run file: {options.TxtFile}");
 

--- a/TxtParser.cs
+++ b/TxtParser.cs
@@ -16,7 +16,7 @@
 
 class TxtParser
 {
-    public static async Task RunFile(string FilePath, GridBot Gunnar)
+    public async Task RunFile(string FilePath, GridBot Gunnar)
     {
         if (File.Exists(FilePath))
         {

--- a/WAYFS-AlphaBot.csproj
+++ b/WAYFS-AlphaBot.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Emgu.CV" Version="4.8.1.5350" />
     <PackageReference Include="Emgu.CV.runtime.windows" Version="4.8.1.5350" />
     <PackageReference Include="MMALSharp" Version="0.6.0" />


### PR DESCRIPTION
Added Command-line arguments to the backend. The Program Main Function now chooses behaviour depending on what parser to use (TxtParser or AppCmdParser). Flag -t or --txt chooses TxtParser, and should be followed by a file name. Flag -u or --urls Chooses AppCmdParser, and should be followed by a valid URL and port (like "http://localhost:5175"). Using the -u flag, another flag, -d or --dummy, Can be set to run the backend without initializing an AlphaBot. This is useful for working on the Front End locally without a working backend.