### PR TITLE
Add NuGet metadata to AlphaBotLib

### DIFF
--- a/Backend/AlphaBotLib/AlphaBotLib.csproj
+++ b/Backend/AlphaBotLib/AlphaBotLib.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- NuGet package metadata -->
+    <PackageId>AlphaBotLib.HiQ</PackageId>
+    <Version>1.0.1</Version>
+    <Authors>Filip Alberius;Rasmus Nordling;Younus Salman</Authors>
+    <Company>HiQ Stockholm AB</Company>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +19,8 @@
     <PackageReference Include="MMALSharp" Version="0.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="System.Device.Gpio" Version="2.2.0-*" />
+    <None Include="docs\README.md" Pack="true" PackagePath="\"/>
+    <None Include="licenses\LICENSE.txt" Pack="true" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/Backend/AlphaBotLib/docs/README.md
+++ b/Backend/AlphaBotLib/docs/README.md
@@ -1,0 +1,51 @@
+# AlphaBot2 Control Library for .NET 7
+
+[![NuGet](https://img.shields.io/nuget/v/AlphaBotLib.HiQ.svg)](https://www.nuget.org/packages/AlphaBotLib.HiQ/)
+
+## Overview
+
+This .NET 7 class library provides convenient interfaces and abstractions for controlling various components of the AlphaBot2 robot. It simplifies the integration of AlphaBot2 components into your .NET applications.
+
+## Components
+
+### Buzzer
+
+The `Buzzer` class enables the control of the onboard buzzer, allowing you to produce beep sounds easily.
+
+### Camera
+
+The `Camera` class provides functionality for streaming and capturing photos from the AlphaBot2's onboard camera.
+
+### Light
+
+The `Light` class facilitates the control of LED lights on the AlphaBot2. Note that this class relies on a 3rd party library, which must be separately installed on the Raspberry Pi. Additionally, running the program as a `sudo` user is required for the lights to function in this initial version.
+
+### Motor
+
+The `Motor` class allows you to control the motors of the AlphaBot2, providing high-level abstractions for motor operations.
+
+### TR Sensor
+
+The `TRSensor` class offers functionality to read data from the TR sensor on the AlphaBot2.
+
+## Getting Started
+
+To use this library in your .NET project, you can install it via NuGet. Open the NuGet Package Manager Console and run the following command:
+
+```bash
+dotnet add package AlphaBotLib.HiQ
+```
+
+## Usage
+
+To get started with using the AlphaBot2 Control Library, follow these steps:
+
+1. Install the NuGet package in your project.
+2. Create an instance of the desired component class (e.g., `**Buzzer**`, `**Camera**`).
+3. Utilize the provided methods and properties to control and interact with the AlphaBot2 components.
+
+Feel free to explore the example application in the [WAYFS-AlphaBot repository](https://github.com/younus10s/WAYFS-AlphaBot) for a practical demonstration.
+
+## License
+
+This library is licensed under the [MIT License](https://mit-license.org/).

--- a/Backend/AlphaBotLib/licenses/LICENSE.txt
+++ b/Backend/AlphaBotLib/licenses/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Filip Alberius, Rasmus Nordling, Younus Salman and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Updated AlphaBotLib.csproj to include necessary NuGet metadata.
- Added README.md and License.txt for NuGet packaging.